### PR TITLE
Add ball, scoring and paddle AI

### DIFF
--- a/Ball.gd
+++ b/Ball.gd
@@ -1,0 +1,31 @@
+extends Node2D
+
+signal scored(side)
+
+var velocity := Vector2(-1, 0)
+const SPEED := 250
+
+func _ready():
+    randomize()
+    reset()
+
+func reset():
+    position = get_viewport_rect().size / 2
+    velocity = Vector2(randf_range(-1, 1), randf_range(-0.5, 0.5)).normalized()
+
+func _process(delta):
+    position += velocity * SPEED * delta
+    var rect := get_viewport_rect()
+    if position.y < 0:
+        position.y = 0
+        velocity.y = abs(velocity.y)
+    elif position.y > rect.size.y:
+        position.y = rect.size.y
+        velocity.y = -abs(velocity.y)
+
+    if position.x < 0:
+        emit_signal("scored", "right")
+        reset()
+    elif position.x > rect.size.x:
+        emit_signal("scored", "left")
+        reset()

--- a/Ball.tscn
+++ b/Ball.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://Ball.gd" type="Script" id=1]
+[ext_resource path="res://icon.svg" type="Texture2D" id=2]
+
+[node name="Ball" type="Node2D"]
+script = ExtResource(1)
+
+[node name="Sprite" type="Sprite2D" parent="."]
+texture = ExtResource(2)
+scale = Vector2(0.1, 0.1)

--- a/Main.gd
+++ b/Main.gd
@@ -1,1 +1,25 @@
 extends Node2D
+
+var score_left := 0
+var score_right := 0
+
+@onready var ball := $Ball
+@onready var score_label := $ScoreLabel
+@onready var left_paddle := $LeftPaddle
+@onready var right_paddle := $RightPaddle
+
+func _ready():
+    ball.connect("scored", _on_ball_scored)
+    right_paddle.is_ai = true
+    right_paddle.ball = ball
+    _update_score()
+
+func _on_ball_scored(side:String) -> void:
+    if side == "left":
+        score_left += 1
+    else:
+        score_right += 1
+    _update_score()
+
+func _update_score():
+    score_label.text = "%d : %d" % [score_left, score_right]

--- a/Paddle.gd
+++ b/Paddle.gd
@@ -1,12 +1,20 @@
 extends Node2D
 
 const SPEED := 300
+@export var is_ai := false
+var ball: Node2D
 
 func _process(delta):
     var move := 0.0
-    if Input.is_action_pressed("ui_up"):
-        move -= 1.0
-    if Input.is_action_pressed("ui_down"):
-        move += 1.0
+    if is_ai and ball:
+        if ball.position.y < position.y:
+            move = -1.0
+        elif ball.position.y > position.y:
+            move = 1.0
+    else:
+        if Input.is_action_pressed("ui_up"):
+            move -= 1.0
+        if Input.is_action_pressed("ui_down"):
+            move += 1.0
     position.y += move * SPEED * delta
     position.y = clamp(position.y, 0.0, get_viewport_rect().size.y)

--- a/main.tscn
+++ b/main.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=5 format=3]
 
 [ext_resource path="res://Paddle.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Main.gd" type="Script" id=2]
+[ext_resource path="res://Ball.tscn" type="PackedScene" id=3]
 
 [node name="Main" type="Node2D"]
 script = ExtResource(2)
@@ -11,3 +12,9 @@ position = Vector2(50, 300)
 
 [node name="RightPaddle" parent="." instance=ExtResource(1)]
 position = Vector2(750, 300)
+
+[node name="Ball" parent="." instance=ExtResource(3)]
+
+[node name="ScoreLabel" type="Label" parent="."]
+position = Vector2(400, 20)
+text = "0 : 0"


### PR DESCRIPTION
## Summary
- add ball scene with movement
- update main scene with ball and score label
- keep track of score in `Main.gd`
- allow right paddle to act as a simple AI

## Testing
- `git status --short`